### PR TITLE
英単語テスト履歴機能を作成

### DIFF
--- a/app/app/Http/Controllers/WordbookTestHistoryController.php
+++ b/app/app/Http/Controllers/WordbookTestHistoryController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Http\Request;
+use App\Services\WordbookService;
+
+class WordbookTestHistoryController extends Controller
+{
+
+    private WordbookService $service;
+
+    public function __construct(WordbookService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function show(?int $id = null)
+    {
+        $query = DB::table('wordbook_tests')->orderByDesc('created_at');
+
+        $test = $id ? $query->where('id', $id)->firstOrFail() : $query->first();
+
+        $newerId = null;
+        $olderId = null;
+        $bookName = null;
+        $bookImagePath = null;
+        $words = null;
+
+        if ($test) {
+            $newerId = DB::table('wordbook_tests')
+                ->where('id', '>', $test->id)
+                ->orderBy('id')
+                ->first()
+                ->id ?? null;
+
+            $olderId = DB::table('wordbook_tests')
+                ->where('id', '<', $test->id)
+                ->orderByDEsc('id')
+                ->first()
+                ->id ?? null;
+
+            $bookName = $this->service->getBookName($test->book);
+            $bookImagePath = $this->service->getBookImagePath($test->book);
+            $words = json_decode($test->test_data);
+        }
+
+        return view('wordbook.test-history', compact('bookName', 'bookImagePath', 'test', 'words', 'newerId', 'olderId'));
+    }
+}

--- a/app/app/Services/WordbookService.php
+++ b/app/app/Services/WordbookService.php
@@ -41,11 +41,31 @@ class WordbookService
             throw new \InvalidArgumentException('終了IDが最大IDを超えています。');
         }
 
-        return DB::table($table)
+        $words = DB::table($table)
             ->whereBetween('id', [$startId, $endId])
             ->inRandomOrder()
             ->limit($count)
             ->get();
+
+        DB::table('wordbook_tests')->insert([
+            'book' => $book,
+            'start_id' => $startId,
+            'end_id' => $endId,
+            'count' => $count,
+            'test_data' => json_encode($words->toArray(), JSON_UNESCAPED_UNICODE),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        
+        $overCount = DB::table('wordbook_tests')->count() - 100;
+        if ($overCount > 0) {
+            DB::table('wordbook_tests')
+                ->orderBy('created_at')
+                ->limit($overCount)
+                ->delete();
+        }
+
+        return $words;
     }
 
     /**

--- a/app/database/migrations/2025_04_22_055807_create_wordbook_tests_table.php
+++ b/app/database/migrations/2025_04_22_055807_create_wordbook_tests_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('wordbook_tests', function (Blueprint $table) {
+            $table->id();
+            $table->string('book');
+            $table->unsignedInteger('start_id');
+            $table->unsignedInteger('end_id');
+            $table->unsignedInteger('count');
+            $table->json('test_data');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('wordbook_tests');
+    }
+};

--- a/app/resources/views/components/head.blade.php
+++ b/app/resources/views/components/head.blade.php
@@ -1,5 +1,9 @@
 <header style="background-color: #2c2c3c; color: #f0f0f0; padding: 10px 20px; display: flex; align-items: center; justify-content: space-between;">
-    <h1 style="margin: 0; font-size: 24px;">英単語テスト Generator ! </h1>
+    <a href="{{ route('top') }}" style="text-decoration: none; color: inherit;">
+        <h1 style="margin: 0; font-size: 28px; font-weight: bold; color: #ffffff;">
+            英単語テスト Generator !
+        </h1>
+    </a>
     <nav>
         <ul style="display: flex; gap: 20px; list-style: none; margin: 0; padding: 0;">
             <li><a href="/" style="color: #e3342f; text-decoration: none;">トップ</a></li>

--- a/app/resources/views/components/sidemenu.blade.php
+++ b/app/resources/views/components/sidemenu.blade.php
@@ -13,5 +13,8 @@
         <li style="margin-bottom: 10px;">
             <a href="{{ route('wordbook.test', ['book' => 'sokutan-jokyu']) }}" style="color: #f0f0f0; text-decoration: none;">速読英単語上級編</a>
         </li>
+        <li style="margin-bottom: 10px;">
+            <a href="{{ route('wordbook.test-history') }}" style="color: #f0f0f0; text-decoration: none;">テスト履歴</a>
+        </li>
     </ul>
 </aside>

--- a/app/resources/views/layouts/base.blade.php
+++ b/app/resources/views/layouts/base.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ $title ?? 'ページタイトル' }}</title>
+    <title>@yield('sectiontitle', 'ページタイトル')</title>
     @vite('resources/js/app.js')
 </head>
 <body style="margin: 0; display: flex; flex-direction: column; min-height: 100vh; background-color: #1e1e2f; color: #f0f0f0;">

--- a/app/resources/views/top.blade.php
+++ b/app/resources/views/top.blade.php
@@ -60,25 +60,25 @@
 
     <div class="container my-4">
         <div class="wordbook-container">
-            <a href="/eitango" class="wordbook-link">
+            <a href="{{ route('wordbook.test', ['book' => 'system-eitango']) }}" class="wordbook-link">
                 <div class="wordbook-card">
                     <h4 class="text-dark">システム英単語</h4>
                     <img src="/images/system-eitango.jpg" alt="システム英単語" class="wordbook-image">
                 </div>
             </a>
-            <a href="/eitango-basic" class="wordbook-link">
+            <a href="{{ route('wordbook.test', ['book' => 'system-eitango-basic']) }}" class="wordbook-link">
                 <div class="wordbook-card">
                     <h4 class="text-dark">システム英単語Basic</h4>
                     <img src="/images/system-eitango-basic.jpg" alt="システム英単語Basic" class="wordbook-image">
                 </div>
             </a>
-            <a href="/target1900" class="wordbook-link">
+            <a href="{{ route('wordbook.test', ['book' => 'target1900']) }}" class="wordbook-link">
                 <div class="wordbook-card">
                     <h4 class="text-dark">Target1900</h4>
                     <img src="/images/target1900.jpg" alt="Target1900" class="wordbook-image">
                 </div>
             </a>
-            <a href="/sokudoku-advanced" class="wordbook-link">
+            <a href="{{ route('wordbook.test', ['book' => 'sokutan-jokyu']) }}" class="wordbook-link">
                 <div class="wordbook-card">
                     <h4 class="text-dark">速読英単語上級編</h4>
                     <img src="/images/sokutan-jokyu.jpg" alt="速読英単語上級編" class="wordbook-image">

--- a/app/resources/views/wordbook/test-history.blade.php
+++ b/app/resources/views/wordbook/test-history.blade.php
@@ -1,0 +1,99 @@
+@extends('layouts.base')
+
+@section('sectiontitle', 'テスト履歴 (' . $bookName . ')')
+
+@section('content')
+    <div class="container">
+        <h2>{{ $bookName }} テスト履歴</h2>
+        <div class="text-center mb-4">
+            <img src="{{ $bookImagePath }}" alt="{{ $bookName }}" style="width: 150px; height: 210px; object-fit: cover;">
+        </div>
+
+        @if ($test)
+            <div class="alert alert-info p-3 mb-3">
+                <ul class="mb-0">
+                    <li>範囲: {{ $test->start_id }} 〜 {{ $test->end_id }}</li>
+                    <li>単語数: {{ $test->count }}</li>
+                    <li>作成日: {{ \Carbon\Carbon::parse($test->created_at)->format('Y/m/d H:i') }}</li>
+                </ul>
+            </div>
+
+            <div class="text-center mt-4">
+                <button id="showAnswerButton" class="btn btn-warning">答えを表示する</button>
+            </div>
+            {{ $olderId }}
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                @if ($newerId)
+                    <a href="{{ route('wordbook.test-history', [$newerId]) }}" class="btn btn-outline-primary">◀︎ 次のテスト</a>
+                @else
+                    <span></span>
+                @endif
+
+                @if ($olderId)
+                    <a href="{{ route('wordbook.test-history', [$olderId]) }}" class="btn btn-outline-primary">前のテスト ▶︎</a>
+                @endif
+            </div>
+
+            <div class="row">
+                <!-- 左側：問題 -->
+                <div class="col-md-6">
+                    <h4>問題</h4>
+                    <ul id="wordList" style="list-style: none; padding-left: 1.5em;">
+                        @foreach ($words as $index => $word)
+                            <li>
+                                ({{ $index + 1 }}) {{ $word->word }}
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+
+                <!-- 右側：答え（最初は隠す） -->
+                <div class="col-md-6" id="answerSection" style="display: none;">
+                    <h4>答え</h4>
+                    <table class="table table-striped table-bordered">
+                        <thead class="thead-dark">
+                            <tr>
+                                <th scope="col">No.</th>
+                                <th scope="col">単語</th>
+                                <th scope="col">意味</th>
+                                <th scope="col">ID</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($words as $index => $word)
+                                <tr>
+                                    <td>{{ $index + 1 }}</td>
+                                    <td>{{ $word->word }}</td>
+                                    <td>{{ $word->meaning }}</td>
+                                    <td>{{ $word->id }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>  
+        @else
+            <div class="alert alert-warning">
+                テストデータが見つかりませんでした。
+            </div>
+        @endif
+    </div>
+    <script>
+    document.getElementById('showAnswerButton').addEventListener('click', function () {
+        const answerSection = document.getElementById('answerSection');
+        if (answerSection.style.display === 'none' || answerSection.style.display === '') {
+            if (confirm('本当に答えを表示させますか？')) {
+                answerSection.style.display = 'block';
+                this.textContent = '答えを隠す';
+                this.classList.remove('btn-warning');
+                this.classList.add('btn-secondary');
+            }
+        } else {
+            answerSection.style.display = 'none';
+            this.textContent = '答えを表示する';
+            this.classList.remove('btn-secondary');
+            this.classList.add('btn-warning');
+        }
+    });
+    </script>  
+@endsection

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -3,9 +3,11 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\TopController;
 use App\Http\Controllers\WordbookTestController;
+use App\Http\Controllers\WordbookTestHistoryController;
 
 Route::get('/', [TopController::class, 'index'])->name('top');
 Route::get('/wordbook/{book}/test', [WordbookTestController::class, 'show'])->name('wordbook.test');
+Route::get('/wordbook/test-history/{id?}', [WordbookTestHistoryController::class, 'show'])->name('wordbook.test-history');
 Route::get('welcome', function () {
     return view('welcome');
 });


### PR DESCRIPTION
https://github.com/h-tsubo/laravel-app-for-docker-study/issues/7#issue-3013647560

> - wordbook_tests（テスト保存用テーブル）を作成
>   - id (PK)
>   - book (英単語帳名: system-eitangoなど)
>   - start-id (英単語テスト開始id)
>   - end-id (英単語テスト終了id)
>   - count (単語数)
>   - test_data (JSON形式で単語リスト保存)
>   - created_at / updated_at
> 
> - 英単語テスト生成と同時に自動でwordbook_testsのレコードを作成
> - 100件超えると自動で物理削除
> - 英単語テスト履歴を表示するviewとcontorllerを作成（null対応）