### PR TITLE
自動生成機能をomit

### DIFF
--- a/app/app/Http/Controllers/WordbookTestController.php
+++ b/app/app/Http/Controllers/WordbookTestController.php
@@ -16,12 +16,29 @@ class WordbookTestController extends Controller
         $this->service = $service;
     }
 
-    public function show(WordbookTestRequest $request, $book)
+    public function show($book) 
     {
         try {
-            $startId = (int) $request->input('start', 1);
-            $endId = (int) $request->input('end', 300);
-            $count = (int) $request->input('count', 50);
+            $startId = null;
+            $endId = null;
+            $count = null;
+
+            $words = null;
+            $bookName = $this->service->getBookName($book);
+            $bookImagePath = $this->service->getBookImagePath($book);
+
+            return view('wordbook.test', compact('words', 'book', 'bookName', 'bookImagePath'));
+        } catch (\InvalidArgumentException $e) {
+            return back()->with('error', $e->getMessage());
+        }
+    }
+
+    public function generateWordbookTest(WordbookTestRequest $request, $book)
+    {
+        try {
+            $startId = (int) $request->input('start');
+            $endId = (int) $request->input('end');
+            $count = (int) $request->input('count');
 
             $words = $this->service->fetchWords($book, $startId, $endId, $count);
             $bookName = $this->service->getBookName($book);

--- a/app/app/Http/Requests/Wordbook/WordbookTestRequest.php
+++ b/app/app/Http/Requests/Wordbook/WordbookTestRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests\Wordbook;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 class WordbookTestRequest extends FormRequest
 {
@@ -30,5 +32,15 @@ class WordbookTestRequest extends FormRequest
                 $validator->errors()->add('count', '取得個数が範囲を超えています。');
             }
         });
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            redirect()
+                ->route('wordbook.test', ['book' => $this->route('book')]) // ★ここにリダイレクトしたいルート名を書く
+                ->withErrors($validator)
+                ->withInput()
+        );
     }
 }

--- a/app/resources/views/wordbook/test-history.blade.php
+++ b/app/resources/views/wordbook/test-history.blade.php
@@ -21,7 +21,6 @@
             <div class="text-center mt-4">
                 <button id="showAnswerButton" class="btn btn-warning">答えを表示する</button>
             </div>
-            {{ $olderId }}
             <div class="d-flex justify-content-between align-items-center mb-4">
                 @if ($newerId)
                     <a href="{{ route('wordbook.test-history', [$newerId]) }}" class="btn btn-outline-primary">◀︎ 次のテスト</a>

--- a/app/resources/views/wordbook/test.blade.php
+++ b/app/resources/views/wordbook/test.blade.php
@@ -33,7 +33,7 @@
         <div class="d-flex align-items-center flex-wrap gap-3 mb-4">
             <button id="showAnswerButton" class="btn btn-warning">答えを表示する</button>
 
-            <form action="{{ route('wordbook.test', ['book' => $book]) }}" method="GET" class="d-flex align-items-center flex-wrap gap-2">
+            <form action="{{ route('wordbook.generate-test', ['book' => $book]) }}" method="GET" class="d-flex align-items-center flex-wrap gap-2">
                 <div class="d-flex align-items-center">
                     <label for="start" class="me-1 mb-0">範囲：</label>
                     <input type="number" name="start" id="start" value="{{ request('start', 1) }}" class="form-control form-control-sm" placeholder="Start ID" style="width: 100px;">
@@ -46,46 +46,52 @@
                     <input type="number" name="count" id="count" value="{{ request('count', 50) }}" class="form-control form-control-sm" placeholder="Count" style="width: 80px;">
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-sm">再取得</button>
+                <button type="submit" class="btn btn-primary btn-sm">テスト生成</button>
             </form>
         </div>
         <div class="row">
-            <!-- 左側：問題 -->
-            <div class="col-md-6">
-                <h4>問題</h4>
-                <ul id="wordList" style="list-style: none; padding-left: 1.5em;">
-                    @foreach ($words as $index => $word)
-                        <li>
-                            ({{ $index + 1 }}) {{ $word->word }}
-                        </li>
-                    @endforeach
-                </ul>
-            </div>
-
-            <!-- 右側：答え（最初は隠す） -->
-            <div class="col-md-6" id="answerSection" style="display: none;">
-                <h4>答え</h4>
-                <table class="table table-striped table-bordered">
-                    <thead class="thead-dark">
-                        <tr>
-                            <th scope="col">No.</th>
-                            <th scope="col">単語</th>
-                            <th scope="col">意味</th>
-                            <th scope="col">ID</th>
-                        </tr>
-                    </thead>
-                    <tbody>
+            @if ($words)
+                <!-- 左側：問題 -->
+                <div class="col-md-6">
+                    <h4>問題</h4>
+                    <ul id="wordList" style="list-style: none; padding-left: 1.5em;">
                         @foreach ($words as $index => $word)
-                            <tr>
-                                <td>{{ $index + 1 }}</td>
-                                <td>{{ $word->word }}</td>
-                                <td>{{ $word->meaning }}</td>
-                                <td>{{ $word->id }}</td>
-                            </tr>
+                            <li>
+                                ({{ $index + 1 }}) {{ $word->word }}
+                            </li>
                         @endforeach
-                    </tbody>
-                </table>
-            </div>
+                    </ul>
+                </div>
+
+                <!-- 右側：答え（最初は隠す） -->
+                <div class="col-md-6" id="answerSection" style="display: none;">
+                    <h4>答え</h4>
+                    <table class="table table-striped table-bordered">
+                        <thead class="thead-dark">
+                            <tr>
+                                <th scope="col">No.</th>
+                                <th scope="col">単語</th>
+                                <th scope="col">意味</th>
+                                <th scope="col">ID</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($words as $index => $word)
+                                <tr>
+                                    <td>{{ $index + 1 }}</td>
+                                    <td>{{ $word->word }}</td>
+                                    <td>{{ $word->meaning }}</td>
+                                    <td>{{ $word->id }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @else
+                <div class="alert alert-warning">
+                    テストを出力してください！
+                </div>
+            @endif
         </div>
     </div>
 

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\WordbookTestHistoryController;
 
 Route::get('/', [TopController::class, 'index'])->name('top');
 Route::get('/wordbook/{book}/test', [WordbookTestController::class, 'show'])->name('wordbook.test');
+Route::get('/wordbook/{book}/generate-test', [WordbookTestController::class, 'generateWordbookTest'])->name('wordbook.generate-test');
 Route::get('/wordbook/test-history/{id?}', [WordbookTestHistoryController::class, 'show'])->name('wordbook.test-history');
 Route::get('welcome', function () {
     return view('welcome');


### PR DESCRIPTION
- 英単語テストページにアクセスする度に自動で英単語テストが生成されると、意図していない大量のテストデータが英単語テストの履歴にレコードとして保存されて、うっとおしくなる。
- 英単語テストを生成しないデフォルトページを作成
- start_id, end_id, countなどのデフォルト値をnullに設定
- エラー時にテストを生成しない